### PR TITLE
Machine conf for raspberrypi4 VM

### DIFF
--- a/conf/machine/include/sel4-vm.inc
+++ b/conf/machine/include/sel4-vm.inc
@@ -1,0 +1,1 @@
+SERIAL_CONSOLES ?= "115200;hvc0"

--- a/conf/machine/vm-raspberrypi4-64.conf
+++ b/conf/machine/vm-raspberrypi4-64.conf
@@ -1,0 +1,5 @@
+# Additional overrides, least specific to most specific
+MACHINEOVERRIDES = "raspberrypi4:raspberrypi4-64:${MACHINE}"
+
+require include/sel4-vm.inc
+require conf/machine/raspberrypi4-64.conf


### PR DESCRIPTION
Add machine configuration for raspberrypi4 VMs. Allows having own
configurations, and vm specific overrides in recipes.

Using own machine keeps both native and VM images functional.